### PR TITLE
Add npm homepage and bugs metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
     "type": "git",
     "url": "https://github.com/jakeklassen/typescript-cli-app-base.git"
   },
+  "homepage": "https://github.com/jakeklassen/typescript-cli-app-base#readme",
+  "bugs": {
+    "url": "https://github.com/jakeklassen/typescript-cli-app-base/issues"
+  },
   "scripts": {
     "build": "pika build",
     "lint": "tslint --project .",


### PR DESCRIPTION
## Summary
- add standard npm `homepage` and `bugs.url` metadata
- keep package name, version, repository, scripts, and runtime code unchanged

## Validation
- `npm view typescript-cli-app-base@0.0.1 name version homepage repository bugs --json` confirmed the published package lacks `homepage` and `bugs`
- `node` metadata smoke check for root `package.json`
- `npm pack --dry-run --ignore-scripts`
- `npx --yes yarn@1.22.22 install --frozen-lockfile --ignore-scripts`
- `npx --yes yarn@1.22.22 build`
- `npx --yes yarn@1.22.22 lint`
- `npx --yes yarn@1.22.22 test`
- Pika output `pkg/package.json` smoke check for `homepage` and `bugs.url`
- `git diff --check`